### PR TITLE
DEV: Resolve `link-to.positional-arguments` deprecation

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-profile-primary/directoryopus-link-status-profile.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-profile-primary/directoryopus-link-status-profile.hbs
@@ -5,7 +5,7 @@
 				<div class="{{opusLinkClass}}">{{d-icon opusLinkIcon}} {{opusLinkText}}</div>
 			{{/if}}
 			{{#if opusCanLinkUser}}
-				<div class="opus-nav-pills">{{#link-to 'linkopus'}}<img class="link-opus-button-icon" src="/plugins/discourse-directoryopus/images/opus_icon.png">{{i18n 'directoryopus.linkopus_title'}}{{/link-to}}</div>
+				<div class="opus-nav-pills">{{#link-to route='linkopus'}}<img class="link-opus-button-icon" src="/plugins/discourse-directoryopus/images/opus_icon.png">{{i18n 'directoryopus.linkopus_title'}}{{/link-to}}</div>
 			{{/if}}
 		</div>
 	{{/if}}


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments

This deprecation happens at build-time, which means it doesn't get surfaced like other deprecations in Discourse themes/plugins.